### PR TITLE
feat: PWA cache font (resolves #37)

### DIFF
--- a/src/pwa/index.ts
+++ b/src/pwa/index.ts
@@ -3,6 +3,52 @@ import { defaultPrimaryColor } from '../palette';
 
 export const vitePWAOptions: Partial<VitePWAOptions> = {
   registerType: 'autoUpdate',
+  workbox: {
+    runtimeCaching: [
+      {
+        urlPattern: /^.*\.(ttf|woff2|eot)/i,
+        handler: 'CacheFirst',
+        options: {
+          cacheName: 'fonts',
+          expiration: {
+            maxEntries: 10,
+            maxAgeSeconds: 60 * 60 * 24 * 365, // <== 365 days
+          },
+          cacheableResponse: {
+            statuses: [0, 200],
+          },
+        },
+      },
+      {
+        urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,
+        handler: 'CacheFirst',
+        options: {
+          cacheName: 'google-fonts-cache',
+          expiration: {
+            maxEntries: 10,
+            maxAgeSeconds: 60 * 60 * 24 * 365, // <== 365 days
+          },
+          cacheableResponse: {
+            statuses: [0, 200],
+          },
+        },
+      },
+      {
+        urlPattern: /^https:\/\/fonts\.gstatic\.com\/.*/i,
+        handler: 'CacheFirst',
+        options: {
+          cacheName: 'gstatic-fonts-cache',
+          expiration: {
+            maxEntries: 10,
+            maxAgeSeconds: 60 * 60 * 24 * 365, // <== 365 days
+          },
+          cacheableResponse: {
+            statuses: [0, 200],
+          },
+        },
+      },
+    ],
+  },
   includeAssets: [
     'favicon.webp',
     'favicon_1024x1024.png',


### PR DESCRIPTION
### What did this PR do (In English)

PWA enable caches of fonts and css files, so that user can run PWA totally offline.

### Screenshots (if contains)

Before: fonts and gstatic css files are not cached

![image](https://user-images.githubusercontent.com/15522311/208415374-a33d58da-7f4d-4249-9f5b-dff5f1e9b3f1.png)

After: fonts and gstatic css files are all cached

![image](https://user-images.githubusercontent.com/15522311/208417338-443f2be4-d887-4166-84ca-640d4687b7d9.png)
